### PR TITLE
Update landing page links and footer icons

### DIFF
--- a/src/screens/LandingPage/LandingPage.tsx
+++ b/src/screens/LandingPage/LandingPage.tsx
@@ -9,6 +9,7 @@ const trailerThumbnail = new URL("../../Images/Posts/image.png", import.meta.url
 const footerDivider = new URL("../../Images/Footer/Layer_1.png", import.meta.url).href;
 const planeImage = new URL("../../Images/Footer/plane.png", import.meta.url).href;
 import { Button } from "../../components/ui/button";
+import { Twitter, BookOpen } from "lucide-react";
 
 // Game feature card images with text baked in
 const gameFeatures = [
@@ -73,10 +74,23 @@ export const LandingPage = (): JSX.Element => {
 
       <div className="relative w-full max-w-screen-2xl mx-auto">
         {/* Navigation */}
-        <header className="relative z-10 flex justify-center pt-8 pb-4">
+        <header className="relative z-10 flex items-center justify-between pt-8 pb-4 px-4 md:px-8">
           <div className="flex items-center group cursor-pointer transition-all duration-300 hover:scale-105">
             <img src={logoImage} alt="Galaxion logo" />
           </div>
+          <Button
+            asChild
+            variant="outline"
+            className="h-10 px-5 bg-white/90 backdrop-blur-sm rounded-[68px] [font-family:'Audiowide',Helvetica] text-[#f9582d] text-sm md:text-base font-medium tracking-wide hover:bg-white hover:scale-105 transition-all duration-300 shadow-xl"
+          >
+            <a
+              href="https://galaxion-fun.gitbook.io/galaxion.fun"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Gitbook
+            </a>
+          </Button>
         </header>
 
         {/* Hero Section */}
@@ -96,13 +110,17 @@ export const LandingPage = (): JSX.Element => {
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 mt-12 justify-center lg:justify-start">
-            <Button className="h-[52px] px-[42px] py-3.5 bg-gradient-to-r from-[#f8572d] to-[#e04d27] rounded-[68px] [font-family:'Audiowide',Helvetica] text-lg font-medium tracking-wide shadow-2xl hover:shadow-[#f8572d]/50 hover:scale-105 transition-all duration-300 border-2 border-[#f8572d]/30 flex items-center gap-3">
-              {/* <img
-                className="w-[33.01px] h-[21.7px] filter drop-shadow-md"
-                alt="Play icon"
-                src={playIcon}
-              /> */}
-              Play Now
+            <Button
+              asChild
+              className="h-[52px] px-[42px] py-3.5 bg-gradient-to-r from-[#f8572d] to-[#e04d27] rounded-[68px] [font-family:'Audiowide',Helvetica] text-lg font-medium tracking-wide shadow-2xl hover:shadow-[#f8572d]/50 hover:scale-105 transition-all duration-300 border-2 border-[#f8572d]/30 flex items-center gap-3"
+            >
+              <a
+                href="https://app.galaxion.fun/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Play Now
+              </a>
             </Button>
             <Button
               variant="outline"
@@ -214,8 +232,17 @@ export const LandingPage = (): JSX.Element => {
               </p>
 
               <div className="flex flex-col sm:flex-row justify-center gap-6">
-                <Button className="h-[52px] px-[57px] py-3.5 bg-gradient-to-r from-[#f8572d] to-[#e04d27] rounded-[68px] [font-family:'Audiowide',Helvetica] text-lg font-medium tracking-wide shadow-2xl hover:shadow-[#f8572d]/50 hover:scale-105 transition-all duration-300 flex items-center gap-[21px] border-2 border-[#f8572d]/30">
-                  Play Now
+                <Button
+                  asChild
+                  className="h-[52px] px-[57px] py-3.5 bg-gradient-to-r from-[#f8572d] to-[#e04d27] rounded-[68px] [font-family:'Audiowide',Helvetica] text-lg font-medium tracking-wide shadow-2xl hover:shadow-[#f8572d]/50 hover:scale-105 transition-all duration-300 flex items-center gap-[21px] border-2 border-[#f8572d]/30"
+                >
+                  <a
+                    href="https://app.galaxion.fun/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Play Now
+                  </a>
                 </Button>
 
                 <Button
@@ -245,8 +272,17 @@ export const LandingPage = (): JSX.Element => {
             </div>
 
             <div className="flex flex-col sm:flex-row gap-4 mb-8">
-              <Button className="h-[52px] px-[57px] py-3.5 bg-gradient-to-r from-[#f8572d] to-[#e04d27] rounded-[68px] [font-family:'Audiowide',Helvetica] text-lg font-medium tracking-wide shadow-2xl hover:shadow-[#f8572d]/50 hover:scale-105 transition-all duration-300 flex items-center gap-[21px] border-2 border-[#f8572d]/30">
-                Play Now
+              <Button
+                asChild
+                className="h-[52px] px-[57px] py-3.5 bg-gradient-to-r from-[#f8572d] to-[#e04d27] rounded-[68px] [font-family:'Audiowide',Helvetica] text-lg font-medium tracking-wide shadow-2xl hover:shadow-[#f8572d]/50 hover:scale-105 transition-all duration-300 flex items-center gap-[21px] border-2 border-[#f8572d]/30"
+              >
+                <a
+                  href="https://app.galaxion.fun/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Play Now
+                </a>
               </Button>
 
               <Button
@@ -255,6 +291,25 @@ export const LandingPage = (): JSX.Element => {
               >
                 Download
               </Button>
+            </div>
+
+            <div className="flex gap-6 mb-8">
+              <a
+                href="https://x.com/Galaxiondotfun"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-white hover:text-[#f8572d]"
+              >
+                <Twitter className="w-6 h-6" />
+              </a>
+              <a
+                href="https://galaxion-fun.gitbook.io/galaxion.fun"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-white hover:text-[#f8572d]"
+              >
+                <BookOpen className="w-6 h-6" />
+              </a>
             </div>
 
             <p className="[font-family:'Montserrat',Helvetica] font-normal text-white/80 text-sm text-center leading-relaxed">

--- a/src/screens/LandingPage/LandingPage.tsx
+++ b/src/screens/LandingPage/LandingPage.tsx
@@ -124,6 +124,12 @@ export const LandingPage = (): JSX.Element => {
             </Button>
             <Button
               variant="outline"
+              onClick={() =>
+                document
+                  .getElementById('trailer-section')?.scrollIntoView({
+                    behavior: 'smooth',
+                  })
+              }
               className="h-[52px] px-[42px] py-3.5 bg-white/95 backdrop-blur-sm rounded-[68px] [font-family:'Audiowide',Helvetica] text-[#f9582d] text-lg font-medium tracking-wide hover:bg-white hover:scale-105 transition-all duration-300 flex items-center gap-3 shadow-xl"
             >
               {/* <img className="w-6 h-6" alt="Download icon" src={downloadLogo} /> */}
@@ -133,7 +139,10 @@ export const LandingPage = (): JSX.Element => {
         </section>
 
         {/* Game Features Section */}
-        <section className="relative z-10 mt-[100px] md:mt-[150px] lg:mt-[200px] px-4 md:px-8 lg:px-[155px]">
+        <section
+          id="trailer-section"
+          className="relative z-10 mt-[100px] md:mt-[150px] lg:mt-[200px] px-4 md:px-8 lg:px-[155px]"
+        >
           <h2 className="text-center [font-family:'Audiowide',Helvetica] font-normal text-white text-3xl md:text-5xl lg:text-[67.1px] mb-8 tracking-wide drop-shadow-2xl">
             GAME FEATURES
           </h2>
@@ -249,7 +258,7 @@ export const LandingPage = (): JSX.Element => {
                   variant="outline"
                   className="h-[52px] px-[51px] py-[13px] bg-white/95 backdrop-blur-sm rounded-[68px] [font-family:'Audiowide',Helvetica] text-[#f9582d] text-lg font-medium tracking-wide hover:bg-white hover:scale-105 transition-all duration-300 flex items-center gap-[21px] shadow-xl"
                 >
-                  Download
+                  Buy Token
                 </Button>
               </div>
             </div>
@@ -289,7 +298,7 @@ export const LandingPage = (): JSX.Element => {
                 variant="outline"
                 className="h-[52px] px-[51px] py-[13px] bg-white/95 backdrop-blur-sm rounded-[68px] [font-family:'Audiowide',Helvetica] text-[#f9582d] text-lg font-medium tracking-wide hover:bg-white hover:scale-105 transition-all duration-300 flex items-center gap-[21px] shadow-xl"
               >
-                Download
+                Buy Token
               </Button>
             </div>
 


### PR DESCRIPTION
## Summary
- link all "Play Now" buttons to the game URL
- add a Gitbook button in the navbar
- show Twitter and Gitbook icons in the footer for social links

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854340e6aa88324bddff3873ec7db2b